### PR TITLE
change dependency version to *

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "require": {
     	"php": ">=5.4.0",
-        "symfony/console": "dev-master"
+        "symfony/console": "*"
     },
     "autoload": {
         "classmap": ["src/"]


### PR DESCRIPTION
dev-master would be rejected because the default minimum-stability is stable while dev-master counts as dev