### PR TITLE
Make compatible with base class

### DIFF
--- a/src/franzliedke/ArrayShortener/ShortenCommand.php
+++ b/src/franzliedke/ArrayShortener/ShortenCommand.php
@@ -54,6 +54,7 @@ class ShortenCommand extends Command
 
 		$output->writeln('');
 		$output->writeln($numFiles.' file(s) processed.');
+		return 0;
 	}
 
 	protected function getIterator($file, InputInterface $input)


### PR DESCRIPTION
Symfony command::execute enforces return type 0, but execute returns nothing.